### PR TITLE
Minor fixes to avoid resolvers from failing

### DIFF
--- a/src/Our.Umbraco.Courier.DataResolvers/GridCellDataResolvers/DocTypeGridEditorGridCellResolverProvider.cs
+++ b/src/Our.Umbraco.Courier.DataResolvers/GridCellDataResolvers/DocTypeGridEditorGridCellResolverProvider.cs
@@ -27,6 +27,9 @@ namespace Our.Umbraco.Courier.DataResolvers.GridCellDataResolvers
                 if (cell == null || cell.Value == null)
                     return false;
 
+                if (cell.Value is JValue)
+                    return false;
+
                 return cell.Value["dtgeContentTypeAlias"] != null && cell.Value["value"] != null;
             }
             catch (Exception ex)

--- a/src/Our.Umbraco.Courier.DataResolvers/PropertyDataResolvers/MultiUrlPickerPropertyDataResolver.cs
+++ b/src/Our.Umbraco.Courier.DataResolvers/PropertyDataResolvers/MultiUrlPickerPropertyDataResolver.cs
@@ -41,7 +41,10 @@ namespace Our.Umbraco.Courier.DataResolvers.PropertyDataResolvers
                         ? ItemProviderIds.mediaItemProviderGuid
                         : ItemProviderIds.documentItemProviderGuid;
 
-                    var nodeGuid = ExecutionContext.DatabasePersistence.GetUniqueId((int)link["id"], objectTypeId);
+                    int linkId;
+                    var nodeGuid = int.TryParse(link["id"].ToString(), out linkId)
+                        ? ExecutionContext.DatabasePersistence.GetUniqueId(linkId, objectTypeId)
+                        : Guid.Empty;
 
                     if (Guid.Empty.Equals(nodeGuid))
                         continue;


### PR DESCRIPTION
The resolver for `RJP.MultiUrlPicker` was casting the `linkid` as an integer, but it might fail so better to do `int.TryParse`.

The `DocTypeGridEditorGridCellResolverProvider` was constantly throwing and logging exceptions, because in many cases it could not run (and in many cases it shouldn't). So I added a check on the cell.Value, as it shouldn't run when its of type `JValue`.

This has been tested on a current version of a customer Project 🍺 

FWIW these changes has also been pushed to https://github.com/umbraco/Umbraco.Courier.Contrib